### PR TITLE
Adding new entry in plist to allow http connections

### DIFF
--- a/WebViewApp/WebViewApp-Info.plist
+++ b/WebViewApp/WebViewApp-Info.plist
@@ -44,5 +44,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key><true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
- For iOS9 we need to add following tags to info.plist to allow http connections

```<key>NSAppTransportSecurity</key>  
     <dict>  
          <key>NSAllowsArbitraryLoads</key><true/>  
     </dict>  
```
- next task would be to update docs.

See https://forums.developer.apple.com/thread/3544  